### PR TITLE
video quality and related videos

### DIFF
--- a/js/jquery.tubular.1.0.js
+++ b/js/jquery.tubular.1.0.js
@@ -28,7 +28,9 @@
         volumeUpClass: 'tubular-volume-up',
         volumeDownClass: 'tubular-volume-down',
         increaseVolumeBy: 10,
-        start: 0
+        start: 0,
+        videoQuality: 'hd1080',
+        relatedVideos: 0
     };
 
     // methods
@@ -57,7 +59,9 @@
                     controls: 0,
                     showinfo: 0,
                     modestbranding: 1,
-                    wmode: 'transparent'
+                    wmode: 'transparent',
+                    vq: options.videoQuality,
+                    rel: options.relatedVideos
                 },
                 events: {
                     'onReady': onPlayerReady,


### PR DESCRIPTION
allows user to specify video quality using the same query string vars as you would with a normal Youtube embed, defaulting to 'hd1080'

allows users to specify whether or not related videos should show at the end of the video, regardless of whether video loops or not
