### PR TITLE
Switch the videos in the background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,74 +1,80 @@
 <!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
-<head>
-	<title>tubular, a YouTube Background Player jQuery Plugin | Sean McCambridge Design</title>
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <link rel="icon" type="image/png" href="/media/layout/favicon.png" />
+	<head>
+		<title>tubular, a YouTube Background Player jQuery Plugin | Sean McCambridge Design</title>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<link rel="icon" type="image/png" href="/media/layout/favicon.png" />
 
-	<link href="css/screen.css" rel="stylesheet" type="text/css" /> 
+		<link href="css/screen.css" rel="stylesheet" type="text/css" /> 
 
-	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js" type="text/javascript"></script>
-	<script type="text/javascript" charset="utf-8" src="js/jquery.tubular.1.0.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/index.js"></script>
-</head>
+		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js" type="text/javascript"></script>
+		<script type="text/javascript" charset="utf-8" src="js/jquery.tubular.1.0.js"></script>
 
-<body>
-<div id="wrapper" class="clearfix">
-	<div id="main">
-		<a href="http://www.seanmccambridge.com/tubular/"><img src="media/logo.png" alt="Tubular logo" id="logo" /></a>
-		<p id="video-controls" class="black-65">Video controls:<br /><a href="#" class="tubular-play">Play</a> | <a href="#" class="tubular-pause">Pause</a> | <a href="#" class="tubular-volume-up">Volume Up</a> | <a href="#" class="tubular-volume-down">Volume Down</a> | <a href="#" class="tubular-mute">Mute</a></p>
-		<div class="black-50">
-			<h1>jQuery tubular</h1>
-			<p>Tubular is a jQuery plugin that lets you set a YouTube video as your page background.  Just attach it to your page wrapper element, set some options, and you're on your way.</p>
-			<p><code>$(<em>page content wrapper element</em>).tubular(<em>options</em>);</code></p>
-		</div>
-		<div class="black-50">
-			<h2>Tubular's <em>hello, world</em></h2>
-			<p>Assuming you're happy with the default options and you use a wrapper div with the id of <em>wrapper</em>, you simply attach to your wrapper div and specify the video you want to load:</p>
-			<p><code>$('#wrapper').tubular({videoId: '0Bmhjf0rKe8'});</code></p>
-			<p>and <em>Presto!</em> ... kittens in your website background!</p>
-		</div>
-		<div class="black-50">
-			<h2>A word of caution</h2>
-			<p>Tubular does not design your website for you. It works here thanks to alpha transparency on these gray boxes and the png logo on the top left. I built tubular thinking it would help experienced web designers and developers add some subtle background elements &mdash; emphasis on subtle &mdash; to their work. I'm sure there are some tasteful ways to use tubular and many, many more not so tasteful ways to use it. With great power comes great responsibility. The kitten example above is not to be taken seriously! :-)</p>
-		</div>
-		<div class="black-50">
-			<h2>Options and defaults</h2>
-			<code>
-				<ul>
-					<li>ratio: 16/9 // usually either 4/3 or 16/9 -- tweak as needed</li>
-	        		<li>videoId: 'ZCAnLxRvNNc' // toy robot in space is a good default, no?</li>
-			        <li>mute: true</li>
-	        		<li>repeat: true</li>
-		        	<li>width: $(window).width() // no need to override</li>
-	        		<li>wrapperZIndex: 99</li>
-	        		<li>playButtonClass: 'tubular-play'</li>
-			        <li>pauseButtonClass: 'tubular-pause'</li>
-			        <li>muteButtonClass: 'tubular-mute'</li>
-			        <li>volumeUpClass: 'tubular-volume-up'</li>
-			        <li>volumeDownClass: 'tubular-volume-down'</li>
-			        <li>increaseVolumeBy: 10 // increment value; volume range is 1-100</li>
-			        <li>start: 0 // starting position in seconds</li>
-	        	</ul>
-	        </code>
-		</div>
-	</div>
-	<div id="sidebar">
-		<div class="black-50">
-			<h2>Download</h2>
-			<p><a href="http://code.google.com/p/jquery-tubular/">Download jQuery tubular on Google Code</a></p>
-		</div>
-		<div class="black-50">
-			<h2>Credits</h2>
-			<p>Beautiful time lapse video of the U.S. Southwest by Tom Lowe and Catherine Laplace-Builhe. <a href="http://www.youtube.com/watch?v=e4Is32W-ppk">Original video here</a>. Code by <a href="http://seanmccambridge.com">Sean McCambridge</a>. Released under <a href="http://opensource.org/licenses/mit-license.php">the MIT License</a>.</p>
-		</div>
-		<div class="black-50">
-			<h2>Remember</h2>
-			<p>Tubular does one thing well. It takes a single video from YouTube at injects it as a full-screen background on a website. It scales the video, offsets the video and provides some basic controls for the video.  That's it.</p>
-			<p>Tubular makes some assumptions on how your website works. First, it assumes you have a single wrapper element under the body tag that envelops all of your website content. It promotes that wrapper to z-index: 99 and position: relative. You can configure the z-index value in the options. So it's assuming your wrapper can accept positioning without breaking your site.</p>
-			<p>Finally, tubular injects the YouTube video you specified as an iframe using fixed position at z-index: 1.  Browsers that do not support fixed positioning will not support tubular. Also, since the YouTube iframe API requires the HTML5 postMessage feature, browsers that do not support it (I'm looking at you, IE7) will not support tubular &mdash; tubular will return false before any changes are made to your CSS in IE7.</p>
-		</div>
-	</div>
-</div><!-- #wrapper -->
-</body>
+	</head>
+	<body>
+		<div id="wrapper" class="clearfix">
+			<div id="main">
+				<a href="http://www.seanmccambridge.com/tubular/"><img src="media/logo.png" alt="Tubular logo" id="logo" /></a>
+				<p id="video-controls" class="black-65">Video controls:<br />
+					<a href="#" class="tubular-play">Play</a> |
+					<a href="#" class="tubular-pause">Pause</a> |
+					<a href="#" class="tubular-volume-up">Volume Up</a> |
+					<a href="#" class="tubular-volume-down">Volume Down</a> |
+					<a href="#" class="tubular-mute">Mute</a>
+				</p>
+				<div class="black-50">
+					<h1>jQuery tubular</h1>
+					<p>Tubular is a jQuery plugin that lets you set a YouTube video as your page background.  Just attach it to your page wrapper element, set some options, and you're on your way.</p>
+					<p><code>$(<em>page content wrapper element</em>).tubular(<em>options</em>);</code></p>
+				</div>
+				<div class="black-50">
+					<h2>Tubular's <em>hello, world</em></h2>
+					<p>Assuming you're happy with the default options and you use a wrapper div with the id of <em>wrapper</em>, you simply attach to your wrapper div and specify the video you want to load:</p>
+					<p><code>$('#wrapper').tubular({videoId: '0Bmhjf0rKe8'});</code></p>
+					<p>and <em>Presto!</em> ... kittens in your website background!</p>
+				</div>
+				<div class="black-50">
+					<h2>A word of caution</h2>
+					<p>Tubular does not design your website for you. It works here thanks to alpha transparency on these gray boxes and the png logo on the top left. I built tubular thinking it would help experienced web designers and developers add some subtle background elements &mdash; emphasis on subtle &mdash; to their work. I'm sure there are some tasteful ways to use tubular and many, many more not so tasteful ways to use it. With great power comes great responsibility. The kitten example above is not to be taken seriously! :-)</p>
+				</div>
+				<div class="black-50">
+					<h2>Options and defaults</h2>
+					<code>
+						<ul>
+							<li>ratio: 16/9 // usually either 4/3 or 16/9 -- tweak as needed</li>
+			        		<li>videoId: 'ZCAnLxRvNNc' // toy robot in space is a good default, no?</li>
+					        <li>mute: true</li>
+			        		<li>repeat: true</li>
+				        	<li>width: $(window).width() // no need to override</li>
+			        		<li>wrapperZIndex: 99</li>
+			        		<li>playButtonClass: 'tubular-play'</li>
+					        <li>pauseButtonClass: 'tubular-pause'</li>
+					        <li>muteButtonClass: 'tubular-mute'</li>
+					        <li>volumeUpClass: 'tubular-volume-up'</li>
+					        <li>volumeDownClass: 'tubular-volume-down'</li>
+					        <li>increaseVolumeBy: 10 // increment value; volume range is 1-100</li>
+					        <li>start: 0 // starting position in seconds</li>
+			        	</ul>
+			        </code>
+				</div>
+			</div>
+			<div id="sidebar">
+				<div class="black-50">
+					<h2>Download</h2>
+					<p><a href="http://code.google.com/p/jquery-tubular/">Download jQuery tubular on Google Code</a></p>
+				</div>
+				<div class="black-50">
+					<h2>Credits</h2>
+					<p>Beautiful time lapse video of the U.S. Southwest by Tom Lowe and Catherine Laplace-Builhe. <a href="http://www.youtube.com/watch?v=e4Is32W-ppk">Original video here</a>. Code by <a href="http://seanmccambridge.com">Sean McCambridge</a>. Released under <a href="http://opensource.org/licenses/mit-license.php">the MIT License</a>.</p>
+				</div>
+				<div class="black-50">
+					<h2>Remember</h2>
+					<p>Tubular does one thing well. It takes a single video from YouTube at injects it as a full-screen background on a website. It scales the video, offsets the video and provides some basic controls for the video.  That's it.</p>
+					<p>Tubular makes some assumptions on how your website works. First, it assumes you have a single wrapper element under the body tag that envelops all of your website content. It promotes that wrapper to z-index: 99 and position: relative. You can configure the z-index value in the options. So it's assuming your wrapper can accept positioning without breaking your site.</p>
+					<p>Finally, tubular injects the YouTube video you specified as an iframe using fixed position at z-index: 1.  Browsers that do not support fixed positioning will not support tubular. Also, since the YouTube iframe API requires the HTML5 postMessage feature, browsers that do not support it (I'm looking at you, IE7) will not support tubular &mdash; tubular will return false before any changes are made to your CSS in IE7.</p>
+				</div>
+			</div>
+		</div><!-- #wrapper -->
+		<script type="text/javascript" charset="utf-8" src="js/index.js"></script>
+	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,9 @@
 					<a href="#" class="tubular-pause">Pause</a> |
 					<a href="#" class="tubular-volume-up">Volume Up</a> |
 					<a href="#" class="tubular-volume-down">Volume Down</a> |
-					<a href="#" class="tubular-mute">Mute</a>
+					<a href="#" class="tubular-mute">Mute</a><br />
+					<a href="#" class="tubular-switch" data-id="f-UGhWj1xww">Video f-UGhWj1xww</a> |
+					<a href="#" class="tubular-switch" data-id="49SKbS7Xwf4">Video 49SKbS7Xwf4</a>
 				</p>
 				<div class="black-50">
 					<h1>jQuery tubular</h1>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js" type="text/javascript"></script>
 	<script type="text/javascript" charset="utf-8" src="js/jquery.tubular.1.0.js"></script>
     <script type="text/javascript" charset="utf-8" src="js/index.js"></script>
-
 </head>
+
 <body>
 <div id="wrapper" class="clearfix">
 	<div id="main">

--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,6 @@
-$('document').ready(function() {
+(function ($, window) {
 	var options = { videoId: 'e4Is32W-ppk', start: 3 };
 	$('#wrapper').tubular(options);
 	// f-UGhWj1xww cool sepia hd
 	// 49SKbS7Xwf4 beautiful barn sepia
-});
+})(jQuery, window);

--- a/js/jquery.tubular.1.0.js
+++ b/js/jquery.tubular.1.0.js
@@ -22,6 +22,7 @@
         mutedButtonClass: 'tubular-muted',
         volumeUpClass: 'tubular-volume-up',
         volumeDownClass: 'tubular-volume-down',
+        switchClass: 'tubular-switch',
         increaseVolumeBy: 10,
         start: 0,
         videoQuality: 'hd1080',
@@ -132,7 +133,11 @@
                 player.setVolume(currentVolume + options.increaseVolumeBy);
             }
             e.preventDefault();
-        });
+        })
+        .on('click', '.' + options.switchClass, function(e) { // switch button
+            player.loadVideoById($(this).data('id'));
+            e.preventDefault();
+        })
     };
 
     // load yt iframe js api

--- a/js/jquery.tubular.1.0.js
+++ b/js/jquery.tubular.1.0.js
@@ -1,19 +1,13 @@
 /* jQuery tubular plugin
-|* by Sean McCambridge
-|* http://www.seanmccambridge.com/tubular
-|* version: 1.0
-|* updated: October 1, 2012
+|* by Antoine Bisch superseeded on Sean McCambridge
+|* http://jahDsign.com
+|* version: 2.0
+|* updated: October 1, 2014
 |* since 2010
-|* licensed under the MIT License
-|* Enjoy.
-|* 
-|* Thanks,
-|* Sean */
+|* licensed under the MIT License */
 
-;(function ($, window) {
+(function ($, window) {
 
-    // test for feature support and return if failure
-    
     // defaults
     var defaults = {
         ratio: 16/9, // usually either 4/3 or 16/9 -- tweak as needed
@@ -34,11 +28,12 @@
     };
 
     // methods
-
     var tubular = function(node, options) { // should be called on the wrapper div
-        var options = $.extend({}, defaults, options),
-            $body = $('body') // cache body node
-            $node = $(node); // cache wrapper node
+        var $window = $(window), //cache window
+            $body = $('body'), // cache body node
+            $node = $(node), // cache wrapper node
+            $tubularPlayer;
+        options = $.extend({}, defaults, options);
 
         // build container
         var tubularContainer = '<div id="tubular-container" style="overflow: hidden; position: fixed; z-index: 1; width: 100%; height: 100%"><div id="tubular-player" style="position: absolute"></div></div><div id="tubular-shield" style="width: 100%; height: 100%; z-index: 2; position: absolute; left: 0; top: 0;"></div>';
@@ -49,9 +44,8 @@
         $node.css({position: 'relative', 'z-index': options.wrapperZIndex});
 
         // set up iframe player, use global scope so YT api can talk
-        window.player;
         window.onYouTubeIframeAPIReady = function() {
-            player = new YT.Player('tubular-player', {
+            window.player = new YT.Player('tubular-player', {
                 width: options.width,
                 height: Math.ceil(options.width / options.ratio),
                 videoId: options.videoId,
@@ -68,28 +62,28 @@
                     'onStateChange': onPlayerStateChange
                 }
             });
-        }
+        };
 
         window.onPlayerReady = function(e) {
+            $tubularPlayer = $('#tubular-player');
             resize();
             if (options.mute) e.target.mute();
             e.target.seekTo(options.start);
             e.target.playVideo();
-        }
+        };
 
         window.onPlayerStateChange = function(state) {
             if (state.data === 0 && options.repeat) { // video ended and repeat option is set true
                 player.seekTo(options.start); // restart
             }
-        }
+        };
 
         // resize handler updates width, height and offset of player after resize/init
         var resize = function() {
-            var width = $(window).width(),
+            var width = $window.width(),
                 pWidth, // player width, to be defined
-                height = $(window).height(),
-                pHeight, // player height, tbd
-                $tubularPlayer = $('#tubular-player');
+                height = $window.height(),
+                pHeight; // player height, tbd
 
             // when screen aspect ratio differs from video, video must center and underlay one dimension
 
@@ -100,46 +94,45 @@
                 pHeight = Math.ceil(width / options.ratio); // get new player height
                 $tubularPlayer.width(width).height(pHeight).css({left: 0, top: (height - pHeight) / 2}); // player height is greater, offset top; reset left
             }
-
-        }
+        };
 
         // events
-        $(window).on('resize.tubular', function() {
-            resize();
-        })
-
-        $('body').on('click','.' + options.playButtonClass, function(e) { // play button
-            e.preventDefault();
+        $window.on('resize.tubular', function() {resize();});
+        $body.on('click','.' + options.playButtonClass, function(e) { // play button
             player.playVideo();
+            e.preventDefault();
         }).on('click', '.' + options.pauseButtonClass, function(e) { // pause button
-            e.preventDefault();
             player.pauseVideo();
+            e.preventDefault();
         }).on('click', '.' + options.muteButtonClass, function(e) { // mute button
+            if (player.isMuted()) {
+                player.unMute();
+            }
+            else {
+                player.mute();
+            }
             e.preventDefault();
-            (player.isMuted()) ? player.unMute() : player.mute();
         }).on('click', '.' + options.volumeDownClass, function(e) { // volume down button
-            e.preventDefault();
             var currentVolume = player.getVolume();
             if (currentVolume < options.increaseVolumeBy) currentVolume = options.increaseVolumeBy;
             player.setVolume(currentVolume - options.increaseVolumeBy);
-        }).on('click', '.' + options.volumeUpClass, function(e) { // volume up button
             e.preventDefault();
+        }).on('click', '.' + options.volumeUpClass, function(e) { // volume up button
             if (player.isMuted()) player.unMute(); // if mute is on, unmute
             var currentVolume = player.getVolume();
             if (currentVolume > 100 - options.increaseVolumeBy) currentVolume = 100 - options.increaseVolumeBy;
             player.setVolume(currentVolume + options.increaseVolumeBy);
-        })
-    }
+            e.preventDefault();
+        });
+    };
 
     // load yt iframe js api
-
-    var tag = document.createElement('script');
-    tag.src = "//www.youtube.com/iframe_api";
-    var firstScriptTag = document.getElementsByTagName('script')[0];
+    var tag = document.createElement('script'),
+        firstScriptTag = document.getElementsByTagName('script')[0];
+    tag.src = '//www.youtube.com/iframe_api';
     firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
 
     // create plugin
-
     $.fn.tubular = function (options) {
         return this.each(function () {
             if (!$.data(this, 'tubular_instantiated')) { // let's only run one
@@ -147,6 +140,6 @@
                 tubular(this, options));
             }
         });
-    }
+    };
 
 })(jQuery, window);

--- a/js/jquery.tubular.1.0.js
+++ b/js/jquery.tubular.1.0.js
@@ -19,6 +19,7 @@
         playButtonClass: 'tubular-play',
         pauseButtonClass: 'tubular-pause',
         muteButtonClass: 'tubular-mute',
+        mutedButtonClass: 'tubular-muted',
         volumeUpClass: 'tubular-volume-up',
         volumeDownClass: 'tubular-volume-down',
         increaseVolumeBy: 10,
@@ -101,27 +102,35 @@
         $body.on('click','.' + options.playButtonClass, function(e) { // play button
             player.playVideo();
             e.preventDefault();
-        }).on('click', '.' + options.pauseButtonClass, function(e) { // pause button
+        })
+        .on('click', '.' + options.pauseButtonClass, function(e) { // pause button
             player.pauseVideo();
             e.preventDefault();
-        }).on('click', '.' + options.muteButtonClass, function(e) { // mute button
+        })
+        .on('click', '.' + options.muteButtonClass, function(e) { // mute button
             if (player.isMuted()) {
                 player.unMute();
+                $(this).removeClass(options.mutedButtonClass);
             }
             else {
                 player.mute();
+                $(this).addClass(options.mutedButtonClass);
             }
             e.preventDefault();
-        }).on('click', '.' + options.volumeDownClass, function(e) { // volume down button
+        })
+        .on('click', '.' + options.volumeDownClass, function(e) { // volume down button
             var currentVolume = player.getVolume();
-            if (currentVolume < options.increaseVolumeBy) currentVolume = options.increaseVolumeBy;
-            player.setVolume(currentVolume - options.increaseVolumeBy);
+            if (currentVolume >= options.increaseVolumeBy) {
+                player.setVolume(currentVolume - options.increaseVolumeBy);
+            }
             e.preventDefault();
-        }).on('click', '.' + options.volumeUpClass, function(e) { // volume up button
+        })
+        .on('click', '.' + options.volumeUpClass, function(e) { // volume up button
             if (player.isMuted()) player.unMute(); // if mute is on, unmute
             var currentVolume = player.getVolume();
-            if (currentVolume > 100 - options.increaseVolumeBy) currentVolume = 100 - options.increaseVolumeBy;
-            player.setVolume(currentVolume + options.increaseVolumeBy);
+            if (currentVolume <= 100) {
+                player.setVolume(currentVolume + options.increaseVolumeBy);
+            }
             e.preventDefault();
         });
     };


### PR DESCRIPTION
Hello,

First of all, well done for creating this plugin, it's the kind of functionality I was looking for without having to code it all from scratch :) And it's been coded brilliantly, up to good standards!

In this fork, I have linted the js code and slightly optimised the caching of elements. Additionally, an option controlled class is added to the mute element so it can be styled differently through CSS to give visual feedback.
The significant change is the addition of the possibility to switch between videos. This is controlled from the HTML through an element of class "tubular-switch" which contains a data-id: the YT video ID to switch to.

I thought it was a nice addition to this great plugin as it allows to create a navigation between different videos.

I would also suggest exposing all the functions available so far (Play | Pause | Volume Up | Volume Down | Mute | Switch) so they could be called from an external script. ie: tubular.mute();

Thank you,

Antoine.
