### PR TITLE
Added 'end' from YouTube API to options

### DIFF
--- a/js/jquery.tubular.1.0.js
+++ b/js/jquery.tubular.1.0.js
@@ -29,6 +29,7 @@
         volumeDownClass: 'tubular-volume-down',
         increaseVolumeBy: 10,
         start: 0,
+        end: false,
         videoQuality: 'hd1080',
         relatedVideos: 0
     };
@@ -61,7 +62,8 @@
                     modestbranding: 1,
                     wmode: 'transparent',
                     vq: options.videoQuality,
-                    rel: options.relatedVideos
+                    rel: options.relatedVideos,
+                    end: options.end
                 },
                 events: {
                     'onReady': onPlayerReady,

--- a/js/jquery.tubular.1.0.js
+++ b/js/jquery.tubular.1.0.js
@@ -60,6 +60,7 @@
                     controls: 0,
                     showinfo: 0,
                     modestbranding: 1,
+                    iv_load_policy: 3,
                     wmode: 'transparent',
                     vq: options.videoQuality,
                     rel: options.relatedVideos,


### PR DESCRIPTION
Setting the end-point (in seconds) of a video via the YouTube API.
Default: false